### PR TITLE
Verisure : "download results" button is not working in a survey

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -1228,7 +1228,8 @@ class SurveyBlock(PollBase, CSVExportMixin):
                 for q in sorted_questions:
                     choices = state.get('choices')
                     if choices:
-                        choice = choices[q[0]]
-                        row.append(answers_dict[choice])
+                        choice = choices.get(q[0])
+                        if choice:
+                            row.append(answers_dict[choice])
                 data[sm.student.id] = row
         return [header_row + questions] + data.values()

--- a/poll/public/js/poll.js
+++ b/poll/public/js/poll.js
@@ -180,7 +180,7 @@ function PollUtil (runtime, element, pollType) {
         }
         if (statusChanged) {
             if (newStatus.last_export_result.error) {
-                self.errorMessage.text(error);
+                self.errorMessage.text(newStatus.last_export_result.error);
                 self.errorMessage.show();
             } else {
                 self.downloadResultsButton.attr('disabled', false);


### PR DESCRIPTION
Task: https://trello.com/c/UgdvFaDG

Related PR: https://github.com/Learningtribes/xblock-poll/pull/6

### Error description:

Test URLs:
https://myvericoach.securitasdirect.fr/courses/course-v1:Myvericoach+FI_TECH_02+2020_T1/courseware/1ba0a59e9c714d2dad0226afb88263eb/5cfc4cffd5ac447b8cff080f16882315/
https://myvericoach.securitasdirect.fr/courses/course-v1:Myvericoach+FCP04+2019_T1/courseware/5a0b67b4a5f64837be285b6afa8b60f6/f8b74d45614e46308693678e9c2bb9ea/

![image](https://user-images.githubusercontent.com/26813045/127444426-8766c846-f7d5-4228-9844-80ef4406c264.png)

```
The content of variable `newStatus` as follow:

download_url: null
export_pending: true
last_export_result:
      error: "u'1602506054508'"


get_export_status: {"export_pending": false, "last_export_result": {"error": "u'1602506054508'"}, "download_url": null}
```

Then: fill the error message from API into html element `errorMessage`.

But why we got error `"1602506054508"` here. Because of failure in celery task: https://github.com/Learningtribes/xblock-poll/blob/33e7a536cdb96d3ea6fd345e6459695ac7ecfd2d/poll/poll.py#L200

### error Logs
command: tail -f lms_default_1-stderr.log
```
2021-07-30 02:24:06,371 INFO 31838 [elasticapm.transport.http] http.py:42 - Sent request, url=https://kibana.learning-tribes.com.cn:8200/intake/v2/events size=7.63kb status=202
2021-07-30 02:24:15,799 INFO 31838 [elasticapm.transport.http] http.py:42 - Sent request, url=https://kibana.learning-tribes.com.cn:8200/intake/v2/events size=0.55kb status=202
2021-07-30 02:25:59,417 INFO 29434 [celery.worker.strategy] strategy.py:60 - Received task: poll.tasks.export_csv_data[cde974b6-2cf8-4958-b99e-d51629ee4cb2]
2021-07-30 02:25:59,539 ERROR 29434 [celery.worker.job] log.py:282 - Task poll.tasks.export_csv_data[cde974b6-2cf8-4958-b99e-d51629ee4cb2] raised unexpected: KeyError(u'1602506054508',)
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/src/xblock-poll/poll/tasks.py", line 24, in export_csv_data
    report_store.store_rows(course_key, filename, src_block.prepare_data())
  File "/edx/app/edxapp/venvs/edxapp/src/xblock-poll/poll/poll.py", line 1231, in prepare_data
    choice = choices[q[0]]
KeyError: u'1602506054508'
2021-07-30 02:26:00,249 INFO 31838 [elasticapm.transport.http] http.py:42 - Sent request, url=https://kibana.learning-tribes.com.cn:8200/intake/v2/events size=7.64kb status=202


2021-07-30 02:26:09,701 INFO 31838 [elasticapm.transport.http] http.py:42 - Sent request, url=https://kibana.learning-tribes.com.cn:8200/intake/v2/events size=0.55kb status=202```

execute shell code: for r in StudentModule.objects.filter(course_id=CourseKey.from_string('course-v1:Myvericoach+FI_TECH_02+2020_T1'), student_id=47480).all()
Output: 
StudentModule<{'course_id': CourseLocator(u'Myvericoach', u'FI_TECH_02', u'2020_T1', None, None), 'student_id': 47480L, 'state': '{"choices": null}', 'module_type': u'survey', 'module_state_key': BlockUsageLocator(CourseLocator(u'Myvericoach', u'FI_TECH_02', u'2020_T1', None, None), u'survey', u'f3de0403197c4135846e7ee863a8fb7b')}>
